### PR TITLE
M1 & Intel Silicon Compatibility, Added Clarity to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,9 @@ From your ~/.dev_env directory, Run the setup_new_mac.sh:
 
 ## _30 second install for bash extensions, git config, idea keymap_
 
-Copy the following into your ~/.bash_profile or similar:
+Copy the following into your ~/.zshrc (or ~/.bash_profile or similar):
 
     . ~/.dev_env/shell_ext_mac_zsh.sh
-
-If needed, Copy the following into your ~/.zshrc or similar:
-
-```console
-if [ -f ~/.bash_profile ]; then
-    . ~/.bash_profile;
-fi
-```
-
 To set up `.gitconfig` and `.gitignore`:
 
     cd ~

--- a/README.md
+++ b/README.md
@@ -2,19 +2,37 @@
 
 A collection of git, and bash utilities, prompts, etc. Opinionated but simple and hackable.
 
-## 30 second install
+You can install it anywhere; in the instructions below **just change ~/.dev_env to any directory you wish.**
 
-You can install it anywhere; in the instructions below just change ~/.dev_env to any directory you wish.
-
-In home dir:
+In home dir [cd ~] or Directory of your choosing:
 
     git clone https://github.com/harlantwood/dev_env.git .dev_env
     # or:
     git clone git@github.com:harlantwood/dev_env.git .dev_env
 
-in your ~/.bash_profile or similar:
+---
+
+## _10 minute batch install for core-nexus repo dependencies (Primarily using Brew)_
+
+From your ~/.dev_env directory, Run the setup_new_mac.sh:
+
+    bash setup_new_mac.sh
+
+---
+
+## _30 second install for bash extensions, git config, idea keymap_
+
+Copy the following into your ~/.bash_profile or similar:
 
     . ~/.dev_env/shell_ext_mac_zsh.sh
+
+If needed, Copy the following into your ~/.zshrc or similar:
+
+```console
+if [ -f ~/.bash_profile ]; then
+    . ~/.bash_profile;
+fi
+```
 
 To set up `.gitconfig` and `.gitignore`:
 
@@ -29,8 +47,10 @@ To set up vscode settings:
     ln -sf ~/.dev_env/vscode/home-lib-app-sup-code-user/keybindings.json
 
 To back up vscode extensions:
-
-    code --list-extensions >> vscode/extensions.txt
+```console
+cd ~/.dev_env
+code --list-extensions >> vscode/extensions.txt
+```
 
 And to reinstall them elsewhere:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In home dir [cd ~] or Directory of your choosing:
 
 ---
 
-## _10 minute batch install for core-nexus repo dependencies (Primarily using Brew)_
+## _10 minute batch install for common dependencies (Primarily using Brew)_
 
 From your ~/.dev_env directory, Run the setup_new_mac.sh:
 

--- a/shell_ext_mac_zsh.sh
+++ b/shell_ext_mac_zsh.sh
@@ -23,7 +23,13 @@ fi
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
-source /opt/homebrew/opt/powerlevel10k/powerlevel10k.zsh-theme
+# HOMEBREW INSTALLATION LOCATION
+if [[ $(uname -m) == 'arm64' ]]; then
+    source /opt/homebrew/opt/powerlevel10k/powerlevel10k.zsh-theme # Apple M1 (arm64)
+  else       
+    source /usr/local/opt/powerlevel10k/powerlevel10k.zsh-theme # Intel (x86_64)          
+fi
+
 
 # [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
 # [[ -r "/usr/local/opt/git/etc/bash_completion.d/git-prompt.sh" ]] && . "/usr/local/opt/git/etc/bash_completion.d/git-prompt.sh"
@@ -46,7 +52,13 @@ SCRIPT_DIR=${0:a:h} # zsh only
 # zsh
 ###############################################################################
 
-export PATH="/opt/homebrew/bin:$PATH"
+if [[ $(uname -m) == 'arm64' ]]; 
+  then
+    export PATH="/opt/homebrew/bin:$PATH" # Apple M1 (arm64)
+  else       
+    export PATH="/usr/local/bin:$PATH" # Intel (x86_64)          
+fi
+
 
 # ###############################################################################
 # # Go
@@ -171,7 +183,10 @@ export NVM_DIR="$HOME/.nvm"
 ###############################################################################
 
 # rbenv:
-eval "$(rbenv init -)"
+
+eval "$(rbenv init -)"                #bash    
+export PATH="$HOME/.rbenv/bin:$PATH"  #zsh
+eval "$(rbenv init - zsh)"            #zsh
 
 # ###############################################################################
 # # asdf


### PR DESCRIPTION
(1) Added check to see if user's system is running Apple M1 or Intel Silicon. Homebrew PATH variables set accordingly. (2) Added some additional Caveats for rbenv installation initializations for zsh. (3) Updated README.md to include running setup_new_mac.sh and additional details linking bash_profile to .zshrc file.